### PR TITLE
Install completion script to bash-completions

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -4,6 +4,7 @@ Section: science
 Priority: optional
 Build-Depends: debhelper (>= 11),
                cmake,
+               dh-exec,
                gem2deb,
                libbackward-cpp-dev,
                ruby,

--- a/ubuntu/debian/ignition-tools.install
+++ b/ubuntu/debian/ignition-tools.install
@@ -1,2 +1,4 @@
+#!/usr/bin/dh-exec
 usr/bin/*
 usr/lib/*/libignition-tools-backward.so
+etc/ign.bash_completion.sh => /usr/share/bash-completion/completions/ign


### PR DESCRIPTION
Install the ign completion script to `/usr/share/bash-completion/completions/` to allow it to be used automatically. This approach is based on the approach used by the `hub` command, which installs the completion script to platform specific locations in the debian metadata, rather than attempting to encode these locations in cmake.

* https://sources.debian.org/src/hub/2.14.2%7Eds1-1/debian/hub.install/

Note that `hub.install` uses `dh-exec-install`, which allows the file to be renamed upon installation. This command has [three requirements](https://manpages.ubuntu.com/manpages/impish/man1/dh_install.1.html#limitations):

* The package must be using compatibility level 9 or later (see [debhelper](https://manpages.ubuntu.com/manpages/impish/man7/debhelper.7.html)(7))

* The package will need a build-dependency on dh-exec.

* The install file must be marked as executable.

Follow-up to https://github.com/ignitionrobotics/ign-tools/pull/77 and related to https://github.com/ignitionrobotics/ign-tools/issues/1.

## Testing

This branch has been tested in the following nightly debbuild job:

* https://build.osrfoundation.org/view/ign-garden/job/ign-tools-debbuilder/467/

I recommend downloading the [`.deb` artifact](https://build.osrfoundation.org/view/ign-garden/job/ign-tools-debbuilder/467/artifact/pkgs/ignition-tools_1.4.1+nightly+git20220311+2r4df357f77a7389fdfc385849f910369440266a12-2%7Efocal_amd64.deb) and installing it with `dpkg -i` and then running the instructions from https://github.com/ignitionrobotics/ign-tools/pull/77.

> Source the script in a terminal window and hit <TAB> after typing ign and see the list of available commands.