### PR TITLE
Add dh-exec build-depend to bionic control file

### DIFF
--- a/bionic/debian/control
+++ b/bionic/debian/control
@@ -4,6 +4,7 @@ Maintainer: Jose Luis Rivero <jrivero@osrfoundation.org>
 Section: science
 Priority: optional
 Build-Depends: debhelper (>= 9~),
+               dh-exec,
                gem2deb,
                cmake,
                pkg-config


### PR DESCRIPTION
The bionic nightlies have been failing since #4 was merged:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-tools-debbuilder&build=477)](https://build.osrfoundation.org/job/ign-tools-debbuilder/477/) https://build.osrfoundation.org/job/ign-tools-debbuilder/477/

The problem is that `dh-exec` wasn't added as a build-depend to the bionic `control` file. This should fix it.

## Testing

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-tools-debbuilder&build=480)](https://build.osrfoundation.org/job/ign-tools-debbuilder/480/) https://build.osrfoundation.org/job/ign-tools-debbuilder/480/